### PR TITLE
Add stdout/stderr suppression for tests that are expected to fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,8 +128,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-tests/.slangslangtorch_cache/
+tests/.slangtorch_cache/
 bin/
 
-# Ignore all slangslangtorch cache folders.
-**/.slangslangtorch_cache/**
+# Ignore all slangtorch cache folders.
+**/.slangtorch_cache/**

--- a/tests/smoke.slang
+++ b/tests/smoke.slang
@@ -3,13 +3,13 @@
 // Verify that we can output a cuda device function with [CudaDeviceExport].
 // Disabled until we have FileCheck.
 
-struct ReturnValue
+public __extern_cpp struct ReturnValue
 {
     TorchTensor<float> v0;
     TorchTensor<float> v1;
 }
 
-struct Inputs
+public __extern_cpp struct Inputs
 {
     TorchTensor<float> input;
     float value;


### PR DESCRIPTION
Avoids clogging up the test output with confusing error messages

+ Fixed an issue with the smoke test being out-of-date.
+ Fixed a gitignore to ignore slangtorch cache directories