### PR TITLE
Support `half` types when compiling CUDA generated from Slang

### DIFF
--- a/tests/autobind-square-half.slang
+++ b/tests/autobind-square-half.slang
@@ -1,0 +1,13 @@
+[AutoPyBindCUDA]
+[CUDAKernel]
+void square(TensorView<half> input, TensorView<half> output)
+{
+    // Get the 'global' index of this thread.
+    uint3 dispatchIdx = cudaThreadIdx() + cudaBlockIdx() * cudaBlockDim();
+
+    // If the thread index is beyond the input size, exit early.
+    if (dispatchIdx.x >= input.size(0))
+        return;
+
+    output[dispatchIdx.x] = input[dispatchIdx.x] * input[dispatchIdx.x];
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -640,3 +640,20 @@ class TestEmptyTensor(unittest.TestCase):
 
         # Should not crash.
 
+class TestHalfDType(unittest.TestCase):
+    def setUp(self) -> None:
+        test_dir = os.path.dirname(os.path.abspath(__file__))
+        slangModuleSourceFile = os.path.join(test_dir, 'autobind-square-half.slang')
+        
+        module = slangtorch.loadModule(slangModuleSourceFile)
+        self.module = module
+
+    def test_half_multiply(self):
+        X = torch.tensor([1., 2., 3., 4.]).cuda().half()
+        Z = torch.zeros_like(X).cuda().half()
+
+        self.module.square(input=X, output=Z).launchRaw(blockSize=(32, 1, 1), gridSize=(1, 1, 1))
+
+        expected = torch.tensor([1., 4., 9., 16.]).cuda().half()
+
+        assert(torch.all(torch.eq(Z, expected)))


### PR DESCRIPTION
This patch fixes an issue with torch's plugin system disabling the `half` type in CUDA. These flags are unnecessary since our CUDA kernels do not use any torch library functions (only the `.cpp` component links against torch's library). 

We fix this by simply 'unsetting' the flags that torch has set.

Fixes main repository issue (https://github.com/shader-slang/slang/issues/4583)