### PR TITLE
Fix vswhere.exe cli options

### DIFF
--- a/slangtorch/slangtorch.py
+++ b/slangtorch/slangtorch.py
@@ -93,7 +93,7 @@ def find_cl():
     vswhere_path = os.environ.get('ProgramFiles(x86)', '') + '\\Microsoft Visual Studio\\Installer\\vswhere.exe'
 
     # Get the installation path of the latest version of Visual Studio
-    result = subprocess.run([vswhere_path, '-latest', '-property', 'installationPath'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.run([vswhere_path, '-latest', '-products', '*', '-property', 'installationPath'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     vs_install_path = result.stdout.decode('utf-8').rstrip()
 
     # Find the path to cl.exe


### PR DESCRIPTION
This fixes the ability to find cl.exe in Visual Studio 2022. Without the "-products *" arguments, the  command returns no results.