### PR TITLE
Update link to Slang user-guide's slangtorch documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This package allows you to use Slang as a language to write
 PyTorch kernels.
 
 Slang user guide: https://shader-slang.com/slang/user-guide/
-`slangtorch` documentation: https://shader-slang.com/slang/user-guide/a1-02-slangpy.html
+`slangtorch` documentation: https://shader-slang.org/slang/docs/user-guide/a1-02-slangpy

--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ This package allows you to use Slang as a language to write
 PyTorch kernels.
 
 Slang user guide: https://shader-slang.com/slang/user-guide/
+
 `slangtorch` documentation: https://shader-slang.org/slang/docs/user-guide/a1-02-slangpy


### PR DESCRIPTION
Fixes #28

The slangtorch documentation was at https://shader-slang.com/slang/user-guide/a1-02-slangpy.html, but that page has been deprecated and moved to https://shader-slang.org/slang/docs/user-guide/a1-02-slangpy, with a note telling users to use SlangPy for new projects.

This PR updates the link in the README to the current location.