### PR TITLE
Include slang-glsl-module.dll to the packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ exclude build.bat
 exclude dist/
 exclude tests/
 include slangtorch/bin/slang.dll
+include slangtorch/bin/slang-glsl-module.dll
 include slangtorch/bin/libslang.so
+include slangtorch/bin/libslang-glsl-module.so
 include slangtorch/bin/slangc
 include slangtorch/bin/slangc.exe

--- a/build-package.sh
+++ b/build-package.sh
@@ -8,8 +8,10 @@ unzip -n $LINUX64ZIP -d ./tmp/linux64
 
 mkdir -p ./slangtorch/bin/
 cp ./tmp/win64/bin/slang.dll ./slangtorch/bin/slang.dll
+cp ./tmp/win64/bin/slang-glsl-module.dll ./slangtorch/bin/slang-glsl-module.dll
 cp ./tmp/win64/bin/slangc.exe ./slangtorch/bin/slangc.exe
 cp ./tmp/linux64/lib/libslang.so ./slangtorch/bin/libslang.so
+cp ./tmp/linux64/lib/libslang-glsl-module.so ./slangtorch/bin/libslang-glsl-module.so
 cp ./tmp/linux64/bin/slangc ./slangtorch/bin/slangc
 chmod +x ./slangtorch/bin/slangc
 


### PR DESCRIPTION
This PR is to include `slang-glsl-module.dll` and `slang-glsl-module.so` to the slangtorch python package.

It is similar to how slangpy was fixed for the same problem,
- https://github.com/shader-slang/slangpy/pull/445

Fixes
- https://github.com/shader-slang/slang-torch/issues/38