### PR TITLE
Fix post- slang-v2025.21 packaging for windows

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -7,7 +7,11 @@ echo "extracting $LINUX64ZIP"
 unzip -n $LINUX64ZIP -d ./tmp/linux64
 
 mkdir -p ./slangtorch/bin/
-cp ./tmp/win64/bin/slang.dll ./slangtorch/bin/
+if [ -e "./tmp/win64/bin/slang-compiler.dll" ]; then
+    cp ./tmp/win64/bin/slang-compiler.dll ./slangtorch/bin/
+else
+    cp ./tmp/win64/bin/slang.dll ./slangtorch/bin/
+fi
 cp ./tmp/win64/bin/slang-glsl-module.dll ./slangtorch/bin/
 cp ./tmp/win64/bin/slangc.exe ./slangtorch/bin/
 if [ -e "./tmp/linux64/lib/libslang-compiler.so" ]; then


### PR DESCRIPTION
Copy the correct slang library on Windows.
If the renamed `slang-compiler.dll` exists, then it's the one to copy.