### PR TITLE
Fix caching problems on Linux and update to v1.3.19

### DIFF
--- a/build-package-local.sh
+++ b/build-package-local.sh
@@ -35,19 +35,19 @@ unzip -n $LINUX64ZIP -d ./tmp/linux64
 
 mkdir -p ./slangtorch/bin/
 if [ -e "./tmp/win64/bin/slang-compiler.dll" ]; then
-    cp ./tmp/win64/bin/slang-compiler.dll ./slangtorch/bin/
+    mv ./tmp/win64/bin/slang-compiler.dll ./slangtorch/bin/
 else
-    cp ./tmp/win64/bin/slang.dll ./slangtorch/bin/
+    mv ./tmp/win64/bin/slang.dll ./slangtorch/bin/
 fi
-cp ./tmp/win64/bin/slang-glsl-module.dll ./slangtorch/bin/
-cp ./tmp/win64/bin/slangc.exe ./slangtorch/bin/
+mv ./tmp/win64/bin/slang-glsl-module.dll ./slangtorch/bin/
+mv ./tmp/win64/bin/slangc.exe ./slangtorch/bin/
 if [ -e "./tmp/linux64/lib/libslang-compiler.so" ]; then
-    cp `realpath ./tmp/linux64/lib/libslang-compiler.so` ./slangtorch/bin/
+    mv `realpath ./tmp/linux64/lib/libslang-compiler.so` ./slangtorch/bin/
 else
-    cp ./tmp/linux64/lib/libslang.so ./slangtorch/bin/
+    mv ./tmp/linux64/lib/libslang.so ./slangtorch/bin/
 fi
-cp ./tmp/linux64/lib/libslang-glsl-module*.so ./slangtorch/bin/
-cp ./tmp/linux64/bin/slangc ./slangtorch/bin/slangc
+mv ./tmp/linux64/lib/libslang-glsl-module*.so ./slangtorch/bin/
+mv ./tmp/linux64/bin/slangc ./slangtorch/bin/slangc
 chmod +x ./slangtorch/bin/slangc
 
 echo "content of ./slangtorch/bin/:"

--- a/build-package-local.sh
+++ b/build-package-local.sh
@@ -25,6 +25,36 @@ export WIN64ZIP="slang-${VERSION}-windows-x86_64.zip"
 echo "LINUX64ZIP: $LINUX64ZIP"
 echo "WIN64ZIP: $WIN64ZIP"
 
-# Run the build script
-echo "Running build-package.sh..."
-bash build-package.sh
+mkdir -p ./tmp
+mkdir -p ./tmp/win64
+mkdir -p ./tmp/linux64
+echo "extracting $WIN64ZIP"
+unzip -n $WIN64ZIP -d ./tmp/win64
+echo "extracting $LINUX64ZIP"
+unzip -n $LINUX64ZIP -d ./tmp/linux64
+
+mkdir -p ./slangtorch/bin/
+if [ -e "./tmp/win64/bin/slang-compiler.dll" ]; then
+    cp ./tmp/win64/bin/slang-compiler.dll ./slangtorch/bin/
+else
+    cp ./tmp/win64/bin/slang.dll ./slangtorch/bin/
+fi
+cp ./tmp/win64/bin/slang-glsl-module.dll ./slangtorch/bin/
+cp ./tmp/win64/bin/slangc.exe ./slangtorch/bin/
+if [ -e "./tmp/linux64/lib/libslang-compiler.so" ]; then
+    cp `realpath ./tmp/linux64/lib/libslang-compiler.so` ./slangtorch/bin/
+else
+    cp ./tmp/linux64/lib/libslang.so ./slangtorch/bin/
+fi
+cp ./tmp/linux64/lib/libslang-glsl-module*.so ./slangtorch/bin/
+cp ./tmp/linux64/bin/slangc ./slangtorch/bin/slangc
+chmod +x ./slangtorch/bin/slangc
+
+echo "content of ./slangtorch/bin/:"
+ls ./slangtorch/bin/
+
+rm $WIN64ZIP
+rm $LINUX64ZIP
+rm -rf ./tmp/
+
+python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "slangtorch"
 version = "1.3.19"
 dependencies = [
-  "torch>=1.1.0",
+  "torch>=2.3.1",
   "hatchling>=1.11.0",
   "ninja",
   "filelock"
@@ -16,7 +16,7 @@ authors = [
 ]
 description = "A package for calling Slang modules from Python and PyTorch."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slangtorch"
-version = "1.3.18"
+version = "1.3.19"
 dependencies = [
   "torch>=1.1.0",
   "hatchling>=1.11.0",
@@ -16,7 +16,7 @@ authors = [
 ]
 description = "A package for calling Slang modules from Python and PyTorch."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/slangtorch/slangtorch.py
+++ b/slangtorch/slangtorch.py
@@ -1,19 +1,19 @@
 import os
 import sys
-import pkg_resources
 import subprocess
 import glob
 import hashlib
 import json
 import re
 import time
+from importlib.metadata import version
 from filelock import FileLock
 
 from .util import jit_compile, run_ninja, NinjaResult
 from .util import wrapModule
 
-packageDir = pkg_resources.resource_filename(__name__, '')
-versionCode = my_version = pkg_resources.get_distribution('slangtorch').version
+packageDir = os.path.dirname(__file__)
+versionCode = version('slangtorch')
 
 DEFAULT_CUDA_CFLAGS = ["-U__CUDA_NO_HALF_OPERATORS__",
                        "-U__CUDA_NO_HALF_CONVERSIONS__",
@@ -89,6 +89,12 @@ def _replaceFileExt(fileName, newExt, suffix=None):
         new_filename = baseName + newExt
     return new_filename
 
+def doesPlatformAllowReload():
+    if sys.platform == "win32":
+        return True
+    else:
+        # Assume linux/unix
+        return False
 
 def find_cl():
     # Look for cl.exe in the default installation path for Visual Studio
@@ -121,6 +127,13 @@ def _add_msvc_to_env_var():
         if path_to_add not in os.environ["PATH"].split(os.pathsep):
             os.environ["PATH"] += os.pathsep + path_to_add
 
+def getPyModuleExtension():
+    if sys.platform == "win32":
+        return "pyd"
+    elif sys.platform == "darwin":
+        return "so"
+    else:
+        return "so"
 
 # Helper functions for tryGetSlangDynamicLibraryPath
 def _tryLddSlangLibPath():
@@ -286,9 +299,9 @@ def getLatestDir(moduleKey, baseDir):
         with open(latestFile, 'r') as f:
             latestBuildID = int(f.read())
     else:
-        return None
+        return (None, 0)
     
-    return makeBuildDirPath(baseDir, latestBuildID)
+    return (makeBuildDirPath(baseDir, latestBuildID), latestBuildID)
 
 
 def getOrCreateUniqueDir(moduleKey, baseDir):
@@ -340,7 +353,7 @@ def getOrCreateUniqueDir(moduleKey, baseDir):
         if (os.path.exists(metadataFile) and os.path.isfile(metadataFile)):
             with open(metadataFile, 'r') as f:
                 metadata = json.load(f)
-                metadata['moduleBinary'] = os.path.join(targetDir, f"{metadata['moduleName']}.pyd")
+                metadata['moduleBinary'] = os.path.join(targetDir, f"{metadata['moduleName'][:-len(f'{latestBuildID}')]}{targetBuildID}.{getPyModuleExtension()}")
 
             with open(metadataFile, 'w') as f:
                 json.dump(metadata, f, indent=4)
@@ -349,7 +362,7 @@ def getOrCreateUniqueDir(moduleKey, baseDir):
     with open(latestFile, 'w') as f:
         f.write(str(targetBuildID))
     
-    return targetDir
+    return targetDir, targetBuildID
 
 
 def compileSlang(metadata, fileName, targetMode, options, outputFile, verbose=False, includePaths=[], dryRun=False, extraSlangFlags=[]):
@@ -480,6 +493,8 @@ def compileAndLoadModule(metadata, sources, moduleName, buildDir, slangSourceDir
     # Check if any of the sources are newer than the module binary.
     if metadata and metadata.get("moduleBinary", None):
         moduleBinary = os.path.realpath(metadata["moduleBinary"])
+        if verbose:
+            print ("Checking module binary at: ", moduleBinary, file=sys.stderr)
         if os.path.exists(moduleBinary):
             for source in sources:
                 if verbose:
@@ -494,6 +509,8 @@ def compileAndLoadModule(metadata, sources, moduleName, buildDir, slangSourceDir
                     needsRebuild = True
                     break
         else:
+            if verbose:
+                print("Module binary does not exist. Rebuilding.", file=sys.stderr)
             needsRebuild = True
     else:
         needsRebuild = True
@@ -530,8 +547,14 @@ def compileAndLoadModule(metadata, sources, moduleName, buildDir, slangSourceDir
         else:
             raise RuntimeError(f"Unknown ninja result: {ninja_result}")
     else:
-        if verbose:
+        if not needsRebuild and skipNinjaCheck and verbose:
             print(f"Skipping additional ninja check (WARNING: this may ignore changes to non-slang files)", file=sys.stderr)
+
+    # If our platform doesn't allow reloading the same binary (e.g. most linux flavors),
+    # then we'll fall back to rebuild.
+    #
+    if needsReload and not doesPlatformAllowReload():
+        needsRebuild = True
 
     cacheLookupKey = moduleName
     if not needsRebuild:
@@ -578,7 +601,7 @@ def compileAndLoadModule(metadata, sources, moduleName, buildDir, slangSourceDir
 
         newMetadata = metadata.copy()
         newMetadata["moduleName"] = moduleName
-        newMetadata["moduleBinary"] = os.path.join(buildDir, f"{moduleName}.pyd")
+        newMetadata["moduleBinary"] = os.path.join(buildDir, f"{moduleName}.{getPyModuleExtension()}")
     
     if dryRun:
         return False, None
@@ -754,9 +777,11 @@ def loadModule(fileName, skipSlang=None, verbose=False, defines={}, includePaths
         extraSlangFlags.append("-line-directive-mode")
         extraSlangFlags.append("none")
 
-    optionsHash = getHash([defines, extraCudaFlags, extraSlangFlags], truncate_at=16)
-    
     parentFolder = os.path.dirname(fileName)
+
+    # We'll include the parent folder in the hash to distinguish between files with the same name in different folders.
+    optionsHash = getHash([defines, extraCudaFlags, extraSlangFlags, parentFolder], truncate_at=16)
+    
     baseNameWoExt = os.path.splitext(os.path.basename(fileName))[0]
     baseOutputFolder = os.path.join(parentFolder, ".slangtorch_cache", baseNameWoExt)
     outputFolder = os.path.join(baseOutputFolder, optionsHash)
@@ -775,13 +800,13 @@ def loadModule(fileName, skipSlang=None, verbose=False, defines={}, includePaths
         moduleName = f"_slangtorch_{convertNonAlphaNumericToUnderscore(baseNameWoExt)}_{optionsHash}"
         
         # Dry run with latest build dir
-        buildDir = getLatestDir(outputFolder, outputFolder)
+        buildDir, buildID = getLatestDir(outputFolder, outputFolder)
 
         if buildDir is not None:
             if verbose:
                 print(f"Dry-run using latest build directory: {buildDir}", file=sys.stderr)
 
-            needsRecompile = _loadModule(fileName, moduleName, buildDir, options, sourceDir=outputFolder, verbose=verbose, includePaths=includePaths, dryRun=True, skipNinjaCheck=skipNinjaCheck, extraCudaFlags=extraCudaFlags, extraSlangFlags=extraSlangFlags)
+            needsRecompile = _loadModule(fileName, f"{moduleName}_{buildID}", buildDir, options, sourceDir=outputFolder, verbose=verbose, includePaths=includePaths, dryRun=True, skipNinjaCheck=skipNinjaCheck, extraCudaFlags=extraCudaFlags, extraSlangFlags=extraSlangFlags)
         else:
             if verbose:
                 print(f"No latest build directory.", file=sys.stderr)
@@ -792,14 +817,14 @@ def loadModule(fileName, skipSlang=None, verbose=False, defines={}, includePaths
             if verbose:
                 print("Build required. Creating unique build directory", file=sys.stderr)
             # Handle versioning
-            buildDir = getOrCreateUniqueDir(outputFolder, outputFolder)
+            buildDir, buildID = getOrCreateUniqueDir(outputFolder, outputFolder)
         else:
             buildDir = buildDir
         
         if verbose:
             print(f"Working folder: {buildDir}", file=sys.stderr)
 
-        rawModule = _loadModule(fileName, moduleName, buildDir, options, sourceDir=outputFolder, verbose=verbose, includePaths=includePaths, dryRun=False, skipNinjaCheck=skipNinjaCheck, extraCudaFlags=extraCudaFlags, extraSlangFlags=extraSlangFlags)
+        rawModule = _loadModule(fileName, f"{moduleName}_{buildID}", buildDir, options, sourceDir=outputFolder, verbose=verbose, includePaths=includePaths, dryRun=False, skipNinjaCheck=skipNinjaCheck, extraCudaFlags=extraCudaFlags, extraSlangFlags=extraSlangFlags)
         addLoadedDirectoryEntry(outputFolder, buildDir)
 
     return wrapModule(rawModule)

--- a/slangtorch/slangtorch.py
+++ b/slangtorch/slangtorch.py
@@ -130,8 +130,6 @@ def _add_msvc_to_env_var():
 def getPyModuleExtension():
     if sys.platform == "win32":
         return "pyd"
-    elif sys.platform == "darwin":
-        return "so"
     else:
         return "so"
 

--- a/slangtorch/slangtorch.py
+++ b/slangtorch/slangtorch.py
@@ -353,7 +353,16 @@ def getOrCreateUniqueDir(moduleKey, baseDir):
         if (os.path.exists(metadataFile) and os.path.isfile(metadataFile)):
             with open(metadataFile, 'r') as f:
                 metadata = json.load(f)
-                metadata['moduleBinary'] = os.path.join(targetDir, f"{metadata['moduleName'][:-len(f'{latestBuildID}')]}{targetBuildID}.{getPyModuleExtension()}")
+                # Safely derive the base module name: only strip the previous
+                # build ID suffix if it is actually present.
+                base_module_name = metadata.get('moduleName', '')
+                latest_id_str = str(latestBuildID)
+                if base_module_name.endswith(latest_id_str):
+                    base_module_name = base_module_name[:-len(latest_id_str)]
+                metadata['moduleBinary'] = os.path.join(
+                    targetDir,
+                    f"{base_module_name}{targetBuildID}.{getPyModuleExtension()}"
+                )
 
             with open(metadataFile, 'w') as f:
                 json.dump(metadata, f, indent=4)

--- a/slangtorch/util/compile.py
+++ b/slangtorch/util/compile.py
@@ -132,12 +132,13 @@ def run_ninja(
     env = os.environ.copy()
     # Try to activate the vc env for the users
     if IS_WINDOWS and 'VSCMD_ARG_TGT_ARCH' not in env:
-        from setuptools import distutils
+        import sysconfig
+        from setuptools.msvc import EnvironmentInfo
 
-        plat_name = distutils.util.get_platform()
+        plat_name = sysconfig.get_platform()
         plat_spec = PLAT_TO_VCVARS[plat_name]
 
-        vc_env = distutils._msvccompiler._get_vc_env(plat_spec)
+        vc_env = EnvironmentInfo(plat_spec).return_env()
         vc_env = {k.upper(): v for k, v in vc_env.items()}
         for k, v in env.items():
             uk = k.upper()


### PR DESCRIPTION
Fixes: https://github.com/shader-slang/slang-torch/issues/42

- When recompiling a module with the same options, use a suffix `_1`, `_2` to create a unique `.so` file. This is to avoid the fact that Linux (and probably all Unix-based platforms) de-duplicate `.so` by name so trying to reload a different .so with the same name would fail to update.
- Add the module file path to the hash code. This allows us to distinguish Slang modules of the same name from different paths. Otherwise, we'll run into the same `.so` name clash problem.
- Update module binary tracking to use `.so` on Linux platforms instead of `.pyd` (which is Windows-only)
- On Linux, we will assume that a module that requires only a reload (and not a rebuild) still requires a rebuild, since reloading the same `.so` doesn't work.