### PR TITLE
feat: Add support for building Linux AArch64 packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,27 @@ jobs:
         file: 'slang-.*-linux-x86_64-glibc-2.27\.zip'
         target: "./"
         regex: true
+    - name: Download artifact - linux-aarch64
+      id: download-linux-aarch64
+      uses: dsaltares/fetch-gh-release-asset@master
+      with:
+        repo: shader-slang/slang
+        file: 'slang-.*-linux-aarch64-glibc-2.28\.zip'
+        target: "./"
+        regex: true
     - name: Copy Slang binaries and Build Package
       run: |
         export TAGNAME=${{ steps.download-win64.outputs.version}}
         export WIN64ZIP=slang-${TAGNAME:1}-windows-x86_64.zip
+        export PACKAGE_PLATFORM=windows-x86_64
+        source build-package.sh
+
         export LINUX64ZIP=slang-${TAGNAME:1}-linux-x86_64-glibc-2.27.zip
+        export PACKAGE_PLATFORM=linux-x86_64
+        source build-package.sh
+
+        export LINUXAARCH64ZIP=slang-${TAGNAME:1}-linux-aarch64-glibc-2.28.zip
+        export PACKAGE_PLATFORM=linux-aarch64
         source build-package.sh
 
         for file in ./dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,27 @@ jobs:
         file: 'slang-.*-linux-x86_64-glibc-2.27\.zip'
         target: "./"
         regex: true
+    - name: Download artifact - linux-aarch64
+      id: download-linux-aarch64
+      uses: dsaltares/fetch-gh-release-asset@master
+      with:
+        repo: shader-slang/slang
+        file: 'slang-.*-linux-aarch64-glibc-2.28\.zip'
+        target: "./"
+        regex: true
     - name: Copy Slang binaries and Build Package
       run: |
         export TAGNAME=${{ steps.download-win64.outputs.version}}
         export WIN64ZIP=slang-${TAGNAME:1}-windows-x86_64.zip
+        export PACKAGE_PLATFORM=windows-x86_64
+        source build-package.sh
+
         export LINUX64ZIP=slang-${TAGNAME:1}-linux-x86_64-glibc-2.27.zip
+        export PACKAGE_PLATFORM=linux-x86_64
+        source build-package.sh
+
+        export LINUXAARCH64ZIP=slang-${TAGNAME:1}-linux-aarch64-glibc-2.28.zip
+        export PACKAGE_PLATFORM=linux-aarch64
         source build-package.sh
 
         for file in ./dist/*

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,33 +1,55 @@
-mkdir -p ./tmp
-mkdir -p ./tmp/win64
-mkdir -p ./tmp/linux64
-echo "extracting $WIN64ZIP"
-unzip -n $WIN64ZIP -d ./tmp/win64
-echo "extracting $LINUX64ZIP"
-unzip -n $LINUX64ZIP -d ./tmp/linux64
+set -euo pipefail
 
-mkdir -p ./slangtorch/bin/
-if [ -e "./tmp/win64/bin/slang-compiler.dll" ]; then
-    cp ./tmp/win64/bin/slang-compiler.dll ./slangtorch/bin/
+case "${PACKAGE_PLATFORM:-}" in
+    windows-x86_64)
+        PACKAGE_ZIP="$WIN64ZIP"
+        PACKAGE_TMP="./tmp/win64"
+        WHEEL_TAG="py3-none-win_amd64"
+        ;;
+    linux-x86_64)
+        PACKAGE_ZIP="$LINUX64ZIP"
+        PACKAGE_TMP="./tmp/linux64"
+        WHEEL_TAG="py3-none-manylinux_2_27_x86_64"
+        ;;
+    linux-aarch64)
+        PACKAGE_ZIP="$LINUXAARCH64ZIP"
+        PACKAGE_TMP="./tmp/linux-aarch64"
+        WHEEL_TAG="py3-none-manylinux_2_28_aarch64"
+        ;;
+    *)
+        echo "Error: PACKAGE_PLATFORM must be one of: windows-x86_64, linux-x86_64, linux-aarch64"
+        exit 1
+        ;;
+esac
+
+rm -rf ./tmp ./slangtorch/bin
+mkdir -p "$PACKAGE_TMP" ./slangtorch/bin/
+echo "extracting $PACKAGE_ZIP"
+unzip -n "$PACKAGE_ZIP" -d "$PACKAGE_TMP"
+
+if [ "$PACKAGE_PLATFORM" = "windows-x86_64" ]; then
+    if [ -e "$PACKAGE_TMP/bin/slang-compiler.dll" ]; then
+        cp "$PACKAGE_TMP/bin/slang-compiler.dll" ./slangtorch/bin/
+    else
+        cp "$PACKAGE_TMP/bin/slang.dll" ./slangtorch/bin/
+    fi
+    cp "$PACKAGE_TMP/bin/slang-glsl-module.dll" ./slangtorch/bin/
+    cp "$PACKAGE_TMP/bin/slangc.exe" ./slangtorch/bin/
 else
-    cp ./tmp/win64/bin/slang.dll ./slangtorch/bin/
+    if [ -e "$PACKAGE_TMP/lib/libslang-compiler.so" ]; then
+        cp "$(realpath "$PACKAGE_TMP/lib/libslang-compiler.so")" ./slangtorch/bin/
+    else
+        cp "$PACKAGE_TMP/lib/libslang.so" ./slangtorch/bin/
+    fi
+    cp "$PACKAGE_TMP"/lib/libslang-glsl-module*.so ./slangtorch/bin/
+    cp "$PACKAGE_TMP/bin/slangc" ./slangtorch/bin/slangc
+    chmod +x ./slangtorch/bin/slangc
 fi
-cp ./tmp/win64/bin/slang-glsl-module.dll ./slangtorch/bin/
-cp ./tmp/win64/bin/slangc.exe ./slangtorch/bin/
-if [ -e "./tmp/linux64/lib/libslang-compiler.so" ]; then
-    cp `realpath ./tmp/linux64/lib/libslang-compiler.so` ./slangtorch/bin/
-else
-    cp ./tmp/linux64/lib/libslang.so ./slangtorch/bin/
-fi
-cp ./tmp/linux64/lib/libslang-glsl-module*.so ./slangtorch/bin/
-cp ./tmp/linux64/bin/slangc ./slangtorch/bin/slangc
-chmod +x ./slangtorch/bin/slangc
 
 echo "content of ./slangtorch/bin/:"
 ls ./slangtorch/bin/
 
-rm $WIN64ZIP
-rm $LINUX64ZIP
+rm "$PACKAGE_ZIP"
 rm -rf ./tmp/
 
 # Detect Python command - check if python has pip module
@@ -55,4 +77,4 @@ $PYTHON_CMD --version
 $PYTHON_CMD -m pip install --upgrade pip
 $PYTHON_CMD -m pip install build hatchling
 
-$PYTHON_CMD -m build
+SLANGTORCH_WHEEL_TAG="$WHEEL_TAG" $PYTHON_CMD -m build --wheel

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,11 @@
+import os
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version, build_data):
+        wheel_tag = os.environ.get("SLANGTORCH_WHEEL_TAG")
+        if wheel_tag:
+            build_data["tag"] = wheel_tag
+            build_data["pure_python"] = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
 ]
 
 [project.urls]
@@ -31,3 +32,6 @@ classifiers = [
 ignore-vcs = true
 include = ["slangtorch/*.py", "slangtorch/bin/*", "slangtorch/util/*.py"]
 exclude = [".github/**", "tests/*.*", "build.bat", "build-package.sh", ".gitignore", "tmp/**"]
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"


### PR DESCRIPTION
  - Build platform-specific wheels instead of packaging multiple OS binaries into one wheel.
  - Add Linux aarch64 support using Slang’s `linux-aarch64-glibc-2.28` release artifact.
  - Tag generated wheels with platform-specific tags:
    - `py3-none-win_amd64`
    - `py3-none-manylinux_2_27_x86_64`
    - `py3-none-manylinux_2_28_aarch64`
  - Mark wheels as non-pure Python via a small Hatch build hook.
  - Clean `slangtorch/bin` between platform builds to avoid cross-platform binary leakage.
  - Update build and publish GitHub Actions to produce Windows x86_64, Linux x86_64, and Linux aarch64 wheels.