### PR TITLE
v1.3.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slangtorch"
-version = "1.3.21"
+version = "1.3.22"
 dependencies = [
   "torch>=2.3.1",
   "hatchling>=1.11.0",


### PR DESCRIPTION
## Summary
- Bump package version to `1.3.22` so we can rebuild/test wheels against the latest Slang release (`v2026.14.1`) before tagging the PyPI publish.

## Test plan
- [x] Wait for **Build SlangTorch** to finish on this PR
- [x] Confirm the build log pulls Slang `v2026.14.1` (or current latest)
- [x] Download the `slangtorch` artifact (win / linux-x86_64 / linux-aarch64 wheels)
- [x] Install and smoke-test linux-x86_64 wheel: `pip install slangtorch-1.3.22-py3-none-manylinux_2_27_x86_64.whl`, then `python -m unittest discover` → 26 tests OK (4 skipped)
- [x] After merge, push tag `v1.3.22` to publish to PyPI